### PR TITLE
Minimum changes required to normalize paths

### DIFF
--- a/.gitattribures
+++ b/.gitattribures
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* eol=lf

--- a/youtub3r.env
+++ b/youtub3r.env
@@ -1,0 +1,4 @@
+TAG=latest
+SERVER_HOST=media-server8:8089
+VIDEO_PATH=/youtube
+DVR_SHARE=/mnt/videos

--- a/youtub3r.yaml
+++ b/youtub3r.yaml
@@ -1,0 +1,12 @@
+services:
+  youtub34:
+    # 2025.09.25
+    # GitHub home for this project with setup instructions: https://github.com/maddox/youtub3r
+    # Docker container home for this project: https://hub.docker.com/r/jonmaddox/youtub3r
+    image: jonmaddox/youtub3r:${TAG:-latest}
+    container_name: youtub3r
+    environment:
+      - SERVER_HOST=${SERVER_HOST}
+      - VIDEO_PATH=${VIDEO_PATH:-/youtube}
+    volumes:
+      - ${DVR_SHARE}:${VIDEO_PATH:-/youtube}


### PR DESCRIPTION
When binding a mounted path from a Linux host OS to a Windows OS, a mixture of slashes and backslashes resulted. As such, the script was failing to recognize valid .json sidecar files. These paths have been normalized to slashes in this commit.

Sample YAML and ENV files have also been added that include a bind mount for a videos directory, with a default name of `/youtube`.  Most all extra logging was removed from the previous PR, in an effort to make as few changes as possible to the current code base.